### PR TITLE
Connect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 .rspec_status
 
 *.bak
+
+examples/from-toml/
+.editorconfig

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  x64-mingw-ucrt
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     obs-websocket (0.1.1)
       concurrent-ruby (~> 1.1)
+      websocket-driver (~> 0.7.5)
 
 GEM
   remote: https://rubygems.org/

--- a/examples/websocket-driver/Gemfile
+++ b/examples/websocket-driver/Gemfile
@@ -1,4 +1,5 @@
-source 'https://rubygems.org'
+# frozen_string_literal: true
+
+source "https://rubygems.org"
 
 gem 'obs-websocket', path: '../..'
-gem 'websocket-driver'

--- a/examples/websocket-driver/Gemfile.lock
+++ b/examples/websocket-driver/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     obs-websocket (0.1.1)
       concurrent-ruby (~> 1.1)
+      websocket-driver (~> 0.7.5)
 
 GEM
   remote: https://rubygems.org/
@@ -13,11 +14,11 @@ GEM
     websocket-extensions (0.1.5)
 
 PLATFORMS
+  x64-mingw-ucrt
   x86_64-linux
 
 DEPENDENCIES
   obs-websocket!
-  websocket-driver
 
 BUNDLED WITH
    2.3.18

--- a/lib/obs/websocket.rb
+++ b/lib/obs/websocket.rb
@@ -35,7 +35,7 @@ module OBS
     class Connection
       attr_reader :socket, :driver, :password
 
-      def initialize(uri: nil, password: nil)
+      def initialize(uri:, password: nil)
           fail ArgumentError, 'Only supports ws:// URI' unless uri.scheme == 'ws'
           @password = password
           @socket = TCPSocket.new(uri.host, uri.port || 4455)

--- a/obs-websocket.gemspec
+++ b/obs-websocket.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'concurrent-ruby', '~> 1.1'
+  spec.add_dependency 'websocket-driver', '~> 0.7.5'
 end


### PR DESCRIPTION
Hello.

This PR introduces the following changes:

- add OBS::WebSocket::Connection. It's constructor accepts uri and password (optional) keyword arguments.
- Since it sets up the driver I've added websocket-driver to runtime dependencies.
- websocket-driver example has been updated to use the Connection class.
- The default port for TCPSocket has been changed to 4455 as per the WebSocket5 docs. I don't know if there was a specific reason it was at 80?

I've tested connecting to several instances of OBS on the same machine and different machines and everything seemed to work.

Any feedback is welcome, thank you for your time.