### PR TITLE
Fix number nil

### DIFF
--- a/lib/obs/websocket.rb
+++ b/lib/obs/websocket.rb
@@ -346,7 +346,7 @@ module OBS
           end
 
           def as_json(f)
-            raise ConversionError.new("nil is not allowed", value: f)
+            raise ConversionError.new("nil is not allowed", value: f) if f.nil?
             f.kind_of?(Integer) ? f : Float(f)
           end
         end


### PR DESCRIPTION
Using the example, adding `obs.get_scene_item_enabled(scene_name: 'NameHere', scene_item_id: 1).wait!` to the `obs.on_open` block, I get `scene_item_id: nil is not allowed: 1`.